### PR TITLE
refactor distribution group membership lookup

### DIFF
--- a/scripts/DryRun-ZimbraMailbox.ps1
+++ b/scripts/DryRun-ZimbraMailbox.ps1
@@ -32,19 +32,15 @@ function Invoke-DryRunZimbraMailbox([string]$UserInput) {
   try {
     $recipient = Get-Recipient -Filter "EmailAddresses -eq '$UserEmail' -or PrimarySmtpAddress -eq '$UserEmail'" -ErrorAction Stop
     if ($recipient) {
-      $groups = Get-DistributionGroup -ResultSize Unlimited | ForEach-Object {
-        $dg = $_
-        try {
-          if ((Get-DistributionGroupMember $dg.Identity -ResultSize Unlimited).PrimarySmtpAddress -contains $UserEmail) {
-            $dg
-          }
-        } catch {}
-      } | Where-Object { $_ } | Select-Object Name | Sort-Object Name
+      $groups = Get-DistributionGroupsByMember $recipient.DistinguishedName |
+        Select-Object DisplayName,PrimarySmtpAddress |
+        Sort-Object DisplayName
     }
   } catch {}
 
   if ($groups -and $groups.Count -gt 0) {
-    Write-Host ("Состоит в {0} рассылк(ах): {1}" -f $groups.Count, ($groups.Name -join ", "))
+    $info = $groups | ForEach-Object { "{0}/{1}" -f $_.DisplayName, $_.PrimarySmtpAddress }
+    Write-Host ("Состоит в {0} рассылк(ах): {1}" -f $groups.Count, ($info -join ", "))
   } else {
     Write-Host "Не состоит ни в одной рассылке (AD-группе)."
   }

--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -1,4 +1,4 @@
-﻿# Экспортирует: Ensure-Module, New-SSHSess
+﻿# Экспортирует: Ensure-Module, New-SSHSess, Get-DistributionGroupsByMember
 
 function Ensure-Module([string]$Name) {
   if (-not (Get-Module -ListAvailable -Name $Name)) {
@@ -19,3 +19,9 @@ function New-SSHSess([string]$SshHost,[string]$SshUser,[string]$SshPass) {
   if (-not $res) { throw "Не удалось открыть SSH к $SshHost" }
   return $res
 }
+
+function Get-DistributionGroupsByMember([string]$dn) {
+  if (-not $dn) { return @() }
+  Get-DistributionGroup -ResultSize Unlimited -Filter "Members -eq '$dn'" -WarningAction SilentlyContinue
+}
+


### PR DESCRIPTION
## Summary
- add `Get-DistributionGroupsByMember` helper to gather distribution lists by member
- refactor dry run and move scripts to use helper and show DisplayName/PrimarySmtpAddress

## Testing
- `pwsh -NoLogo -NoProfile -Command ". ./scripts/utils.ps1; Get-Command Get-DistributionGroupsByMember"` *(failed: command not found)*
- `apt-get update` *(failed: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a850f53fc0832d847d1848284dcdf7