### PR TITLE
Use explicit distribution group member enumeration

### DIFF
--- a/scripts/DryRun-ZimbraMailbox.ps1
+++ b/scripts/DryRun-ZimbraMailbox.ps1
@@ -32,7 +32,7 @@ function Invoke-DryRunZimbraMailbox([string]$UserInput) {
   try {
     $recipient = Get-Recipient -Filter "EmailAddresses -eq '$UserEmail' -or PrimarySmtpAddress -eq '$UserEmail'" -ErrorAction Stop
     if ($recipient) {
-      $groups = Get-DistributionGroupsByMember $recipient.DistinguishedName |
+      $groups = Get-DistributionGroupsByMember $UserEmail |
         Select-Object DisplayName,PrimarySmtpAddress |
         Sort-Object DisplayName
     }

--- a/scripts/Move-ZimbraMailbox.ps1
+++ b/scripts/Move-ZimbraMailbox.ps1
@@ -20,7 +20,7 @@ function Invoke-MoveZimbraMailbox([string]$UserInput) {
         try {
           $recipient = Get-Recipient -Filter "EmailAddresses -eq '$UserEmail' -or PrimarySmtpAddress -eq '$UserEmail'" -ErrorAction Stop
           if ($recipient) {
-            $contactGroups = Get-DistributionGroupsByMember $recipient.DistinguishedName |
+            $contactGroups = Get-DistributionGroupsByMember $UserEmail |
               Select-Object DisplayName,PrimarySmtpAddress,DistinguishedName |
               Sort-Object DisplayName
             if ($contactGroups -and $contactGroups.Count -gt 0) {

--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -20,8 +20,14 @@ function New-SSHSess([string]$SshHost,[string]$SshUser,[string]$SshPass) {
   return $res
 }
 
-function Get-DistributionGroupsByMember([string]$dn) {
-  if (-not $dn) { return @() }
-  Get-DistributionGroup -ResultSize Unlimited -Filter "Members -eq '$dn'" -WarningAction SilentlyContinue
+function Get-DistributionGroupsByMember([string]$mail) {
+  if (-not $mail) { return @() }
+  Get-DistributionGroup -ResultSize Unlimited -ErrorAction SilentlyContinue | Where-Object {
+    try {
+      (Get-DistributionGroupMember $_.Identity -ResultSize Unlimited -ErrorAction SilentlyContinue).PrimarySmtpAddress -contains $mail
+    } catch {
+      $false
+    }
+  }
 }
 


### PR DESCRIPTION
## Summary
- replace `Get-DistributionGroupsByMember` implementation to enumerate groups via `Get-DistributionGroupMember`
- search distribution group memberships by mailbox address when migrating or checking

## Testing
- `pwsh -NoProfile -Command ". ./scripts/utils.ps1"` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a85eb2e6f0832d83f2e216373653a6