### PR TITLE
Handle distribution group lookup without recipient presence

### DIFF
--- a/scripts/DryRun-ZimbraMailbox.ps1
+++ b/scripts/DryRun-ZimbraMailbox.ps1
@@ -29,13 +29,11 @@ function Invoke-DryRunZimbraMailbox([string]$UserInput) {
 
   # Сбор членств в рассылках
   $groups = @()
+  try { $recipient = Get-Recipient -Identity $UserEmail -ErrorAction Stop } catch { $recipient = $null }
   try {
-    $recipient = Get-Recipient -Filter "EmailAddresses -eq '$UserEmail' -or PrimarySmtpAddress -eq '$UserEmail'" -ErrorAction Stop
-    if ($recipient) {
-      $groups = Get-DistributionGroupsByMember $UserEmail |
-        Select-Object DisplayName,PrimarySmtpAddress |
-        Sort-Object DisplayName
-    }
+    $groups = Get-DistributionGroupsByMember $UserEmail |
+      Select-Object DisplayName,PrimarySmtpAddress |
+      Sort-Object DisplayName
   } catch {}
 
   if ($groups -and $groups.Count -gt 0) {

--- a/scripts/Move-ZimbraMailbox.ps1
+++ b/scripts/Move-ZimbraMailbox.ps1
@@ -17,23 +17,22 @@ function Invoke-MoveZimbraMailbox([string]$UserInput) {
 
     if ($mailContact) {
       Write-Host "Найден MailContact: $($mailContact.Identity) — проверяю членства в рассылках..."
+        try { $recipient = Get-Recipient -Identity $UserEmail -ErrorAction Stop } catch { $recipient = $null }
         try {
-          $recipient = Get-Recipient -Filter "EmailAddresses -eq '$UserEmail' -or PrimarySmtpAddress -eq '$UserEmail'" -ErrorAction Stop
-          if ($recipient) {
-            $contactGroups = Get-DistributionGroupsByMember $UserEmail |
-              Select-Object DisplayName,PrimarySmtpAddress,DistinguishedName |
-              Sort-Object DisplayName
-            if ($contactGroups -and $contactGroups.Count -gt 0) {
-              $groupList = $contactGroups | ForEach-Object { "{0}/{1}" -f $_.DisplayName, $_.PrimarySmtpAddress }
-              Write-Host ("Контакт состоит в {0} групп(ах): {1}" -f $contactGroups.Count, ($groupList -join ", "))
-            } else {
-              Write-Host "Контакт не состоит ни в одной рассылке (AD-группе)."
-            }
-          } else {
-            Write-Host "Объект с адресом $UserEmail не найден."
-          }
+          $contactGroups = Get-DistributionGroupsByMember $UserEmail |
+            Select-Object DisplayName,PrimarySmtpAddress,DistinguishedName |
+            Sort-Object DisplayName
         } catch {
           Write-Warning "Не удалось определить членства контакта в группах: $($_.Exception.Message)"
+        }
+        if (-not $recipient) {
+          Write-Host "Объект с адресом $UserEmail не найден."
+        }
+        if ($contactGroups -and $contactGroups.Count -gt 0) {
+          $groupList = $contactGroups | ForEach-Object { "{0}/{1}" -f $_.DisplayName, $_.PrimarySmtpAddress }
+          Write-Host ("Контакт состоит в {0} групп(ах): {1}" -f $contactGroups.Count, ($groupList -join ", "))
+        } else {
+          Write-Host "Контакт не состоит ни в одной рассылке (AD-группе)."
         }
 
       # Теперь удаляем сам почтовый контакт


### PR DESCRIPTION
## Summary
- Ensure DryRun and Move scripts search distribution groups even if Get-Recipient fails
- Switch Get-Recipient calls to use `-Identity` rather than filtering

## Testing
- `pwsh -NoLogo -NoProfile -Command "Write-Host 'Testing post-commit'"` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a86272048c832dbfc8cb6c84b9cff0