### PR TITLE
refactor: get distribution groups via filter

### DIFF
--- a/scripts/DryRun-ZimbraMailbox.ps1
+++ b/scripts/DryRun-ZimbraMailbox.ps1
@@ -29,7 +29,6 @@ function Invoke-DryRunZimbraMailbox([string]$UserInput) {
 
   # Сбор членств в рассылках
   $groups = @()
-  try { $recipient = Get-Recipient -Identity $UserEmail -ErrorAction Stop } catch { $recipient = $null }
   try {
     $groups = Get-DistributionGroupsByMember $UserEmail |
       Select-Object DisplayName,PrimarySmtpAddress |

--- a/scripts/Move-ZimbraMailbox.ps1
+++ b/scripts/Move-ZimbraMailbox.ps1
@@ -17,16 +17,12 @@ function Invoke-MoveZimbraMailbox([string]$UserInput) {
 
     if ($mailContact) {
       Write-Host "Найден MailContact: $($mailContact.Identity) — проверяю членства в рассылках..."
-        try { $recipient = Get-Recipient -Identity $UserEmail -ErrorAction Stop } catch { $recipient = $null }
         try {
           $contactGroups = Get-DistributionGroupsByMember $UserEmail |
             Select-Object DisplayName,PrimarySmtpAddress,DistinguishedName |
             Sort-Object DisplayName
         } catch {
           Write-Warning "Не удалось определить членства контакта в группах: $($_.Exception.Message)"
-        }
-        if (-not $recipient) {
-          Write-Host "Объект с адресом $UserEmail не найден."
         }
         if ($contactGroups -and $contactGroups.Count -gt 0) {
           $groupList = $contactGroups | ForEach-Object { "{0}/{1}" -f $_.DisplayName, $_.PrimarySmtpAddress }

--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -22,12 +22,13 @@ function New-SSHSess([string]$SshHost,[string]$SshUser,[string]$SshPass) {
 
 function Get-DistributionGroupsByMember([string]$mail) {
   if (-not $mail) { return @() }
-  Get-DistributionGroup -ResultSize Unlimited -ErrorAction SilentlyContinue | Where-Object {
-    try {
-      (Get-DistributionGroupMember $_.Identity -ResultSize Unlimited -ErrorAction SilentlyContinue).PrimarySmtpAddress -contains $mail
-    } catch {
-      $false
-    }
+
+  try {
+    $recipient = Get-Recipient -Identity $mail -ErrorAction Stop
+  } catch {
+    return @()
   }
+
+  Get-DistributionGroup -Filter "Members -eq '$($recipient.DistinguishedName)'" -ResultSize Unlimited
 }
 


### PR DESCRIPTION
## Summary
- resolve distribution group membership by filtering on the recipient's distinguished name
- capture member groups before contact deletion in dry-run and move scripts

## Testing
- ⚠️ `pwsh -NoLogo -NoProfile -Command "Import-Module ./scripts/utils.ps1; Import-Module ./scripts/DryRun-ZimbraMailbox.ps1; Import-Module ./scripts/Move-ZimbraMailbox.ps1"` *(pwsh not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a86503795c832dbd1d615e47c0ce9e