### PR TITLE
Clean up contact group lookup in Move-ZimbraMailbox

### DIFF
--- a/scripts/Move-ZimbraMailbox.ps1
+++ b/scripts/Move-ZimbraMailbox.ps1
@@ -17,19 +17,15 @@ function Invoke-MoveZimbraMailbox([string]$UserInput) {
 
     if ($mailContact) {
       Write-Host "Найден MailContact: $($mailContact.Identity) — проверяю членства в рассылках..."
-        try {
-          $contactGroups = Get-DistributionGroupsByMember $UserEmail |
-            Select-Object DisplayName,PrimarySmtpAddress,DistinguishedName |
-            Sort-Object DisplayName
-        } catch {
-          Write-Warning "Не удалось определить членства контакта в группах: $($_.Exception.Message)"
-        }
-        if ($contactGroups -and $contactGroups.Count -gt 0) {
-          $groupList = $contactGroups | ForEach-Object { "{0}/{1}" -f $_.DisplayName, $_.PrimarySmtpAddress }
-          Write-Host ("Контакт состоит в {0} групп(ах): {1}" -f $contactGroups.Count, ($groupList -join ", "))
-        } else {
-          Write-Host "Контакт не состоит ни в одной рассылке (AD-группе)."
-        }
+      $contactGroups = Get-DistributionGroupsByMember $UserEmail |
+        Select-Object DisplayName,PrimarySmtpAddress,DistinguishedName |
+        Sort-Object DisplayName
+      if ($contactGroups -and $contactGroups.Count -gt 0) {
+        $groupList = $contactGroups | ForEach-Object { "{0}/{1}" -f $_.DisplayName, $_.PrimarySmtpAddress }
+        Write-Host ("Контакт состоит в {0} групп(ах): {1}" -f $contactGroups.Count, ($groupList -join ", "))
+      } else {
+        Write-Host "Контакт не состоит ни в одной рассылке (AD-группе)."
+      }
 
       # Теперь удаляем сам почтовый контакт
       try {


### PR DESCRIPTION
## Summary
- remove leftover merge conflict remnants in Move-ZimbraMailbox
- simplify contact group lookup and reporting

## Testing
- `pwsh -NoLogo -NoProfile -Command "Set-StrictMode -Version Latest; . ./scripts/Move-ZimbraMailbox.ps1"` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a86b9894e0832dbe5e492deb8e4e90