### PR TITLE
Add unified contact tool and neutralize domain references

### DIFF
--- a/Migration-Mailbox.ps1
+++ b/Migration-Mailbox.ps1
@@ -1,7 +1,7 @@
 ﻿[CmdletBinding(DefaultParameterSetName="Single")]
 param(
   # Режим 1: один пользователь
-  [Parameter(ParameterSetName="Single", Mandatory=$true, HelpMessage="user или user@mtzd.ru")]
+  [Parameter(ParameterSetName="Single", Mandatory=$true, HelpMessage="user или user@example.com")]
   [string]$User,
 
   # Режим 2: пакетный (файл со списком пользователей)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - при запуске с `-Dryrun` выполняет сухой прогон: проверяет наличие mailbox и подключение к серверам;
 - при использовании `-Force` переименовывает старый ящик в Zimbra (`user_old@domain`);
 - при использовании `-Force` создаёт/обновляет `transport` в **PMG**;
-- приводит **UPN (Имя для входа)** к суффиксу `mtzd.ru` (или `$UpnSuffix` из конфига);
+- приводит **UPN (Имя для входа)** к суффиксу `example.com` (или `$UpnSuffix` из конфига);
 - пишет подробные логи на Windows и на сервере Zimbra.
 
 ---
@@ -26,7 +26,7 @@
 ```
 # список к миграции
 ivan.petrov
-maria.ivanova@mtzd.ru
+maria.ivanova@example.com
 ```
 
 ---
@@ -59,20 +59,20 @@ Install-Module Posh-SSH -Scope AllUsers -Force
 Откройте и заполните ключевые поля:
 
 ```powershell
-$Domain                 = "mtzd.ru"
+$Domain                 = "example.com"
 $AdminLogin             = "EXCH\imapadmin"        # учётка, получающая FullAccess и IMAP proxy-auth
 
-$ExchangeImapHost       = "mail01.mtzd.ru"
-$ZimbraImapHost         = "zimbra.mtzd.ru"
+$ExchangeImapHost       = "mail01.example.com"
+$ZimbraImapHost         = "zimbra.example.com"
 
 $AdminImapPasswordPlain = "SuperSecret"
 
-$ZimbraSshHost          = "zimbra.mtzd.ru"
+$ZimbraSshHost          = "zimbra.example.com"
 $ZimbraSshUser          = "root"
 $ZimbraSshPasswordPlain = "RootPass"
 $ImapSyncPath           = "/usr/bin/imapsync"
 
-$PMGHost                = "pmg.mtzd.ru"
+$PMGHost                = "pmg.example.com"
 $PMGUser                = "root"
 $PMGPasswordPlain       = "RootPass"
 
@@ -80,7 +80,7 @@ $LocalLogDir            = ".\ImapSyncLogs"
 $ExchangeMgmtHost       = "localhost"
 
 # Важно для «Имя для входа» (UPN):
-$UpnSuffix              = "mtzd.ru"
+$UpnSuffix              = "example.com"
 ```
 
 > Пароли хранятся в открытом виде. Ограничьте доступ к файлам NTFS-правами. При желании можно позже перевести на хранилище учётных данных.
@@ -91,7 +91,7 @@ $UpnSuffix              = "mtzd.ru"
 
 1. Нормализует адрес: `user` → `user@$Domain`.
 2. Проверяет mailbox в Exchange; если нет — **Enable-Mailbox** и пауза 60 сек.
-3. Приводит UPN к `$UpnSuffix` (например, `mailtest@mtzd.ru`).
+3. Приводит UPN к `$UpnSuffix` (например, `mailtest@example.com`).
 4. Включает IMAP: `Set-CASMailbox -ImapEnabled $true`.
 5. Выдаёт FullAccess администратору `$AdminLogin`.
 6. На Zimbra по SSH готовит и запускает **imapsync** с повторами и логированием (stream в файл в `$LocalLogDir`).
@@ -113,7 +113,7 @@ $UpnSuffix              = "mtzd.ru"
 ```powershell
 .\Migration-Mailbox.ps1 -User ivan.petrov
 # или явный адрес
-.\Migration-Mailbox.ps1 -User ivan.petrov@mtzd.ru
+.\Migration-Mailbox.ps1 -User ivan.petrov@example.com
 ```
 
 ### Пакетный режим
@@ -152,9 +152,9 @@ $UpnSuffix              = "mtzd.ru"
 В Exchange:
 
 ```powershell
-Get-Mailbox -Identity ivan.petrov@mtzd.ru
-Get-CASMailbox -Identity ivan.petrov@mtzd.ru | fl ImapEnabled
-Get-MailboxPermission -Identity ivan.petrov@mtzd.ru | ? {$_.User -match 'imapadmin'}
+Get-Mailbox -Identity ivan.petrov@example.com
+Get-CASMailbox -Identity ivan.petrov@example.com | fl ImapEnabled
+Get-MailboxPermission -Identity ivan.petrov@example.com | ? {$_.User -match 'imapadmin'}
 ```
 
 В AD (UPN):
@@ -166,14 +166,14 @@ Get-ADUser -LDAPFilter "(sAMAccountName=ivan.petrov)" -Properties userPrincipalN
 В PMG (по SSH):
 
 ```bash
-grep "^ivan.petrov@mtzd.ru" /etc/pmg/transport
-postmap -q "ivan.petrov@mtzd.ru" /etc/pmg/transport
+grep "^ivan.petrov@example.com" /etc/pmg/transport
+postmap -q "ivan.petrov@example.com" /etc/pmg/transport
 ```
 
 В Zimbra (по SSH):
 
 ```bash
-su - zimbra -c 'zmprov ga ivan.petrov_old@mtzd.ru | egrep "mail|zimbraMailAlias"'
+su - zimbra -c 'zmprov ga ivan.petrov_old@example.com | egrep "mail|zimbraMailAlias"'
 ```
 
 ---

--- a/test-function/Contact.ps1
+++ b/test-function/Contact.ps1
@@ -1,0 +1,189 @@
+[CmdletBinding(DefaultParameterSetName="Export")]
+param(
+  [Parameter(ParameterSetName="Export", Mandatory=$true, HelpMessage="Путь к CSV для экспорта")]
+  [string]$Export,
+
+  [Parameter(ParameterSetName="Export")]
+  [string]$SourceOU = "DC=example,DC=com",
+
+  [Parameter(ParameterSetName="Import", Mandatory=$true, HelpMessage="Путь к CSV для импорта")]
+  [string]$Import,
+
+  [Parameter(ParameterSetName="Import")]
+  [string]$TargetOU = "OU=ExternalContacts,DC=example,DC=com"
+)
+
+if ($PSCmdlet.ParameterSetName -eq "Export") {
+  Get-ADUser -SearchBase $SourceOU `
+             -SearchScope Subtree `
+             -LDAPFilter '(&(objectCategory=person)(objectClass=user)(mail=*))' `
+             -Properties mail,displayName,givenName,sn,sAMAccountName,company,department,title,
+                        telephoneNumber,mobile,facsimileTelephoneNumber,streetAddress,l,st,postalCode,co,c,info |
+    Select-Object `
+        @{n='Name';e={ if ($_.displayName) { $_.displayName } elseif ($_.Name) { $_.Name } else { $_.sAMAccountName } }},
+        @{n='DisplayName';e={$_.displayName}},
+        @{n='FirstName';e={$_.givenName}},
+        @{n='LastName';e={$_.sn}},
+        @{n='Alias';e={ ($_.sAMAccountName -replace '[^a-zA-Z0-9._-]','' ).ToLower() }},
+        @{n='ExternalEmailAddress';e={$_.mail}},
+        @{n='Company';e={$_.company}},
+        @{n='Department';e={$_.department}},
+        @{n='Title';e={$_.title}},
+        @{n='Phone';e={$_.telephoneNumber}},
+        @{n='MobilePhone';e={$_.mobile}},
+        @{n='Fax';e={$_.facsimileTelephoneNumber}},
+        @{n='StreetAddress';e={$_.streetAddress}},
+        @{n='City';e={$_.l}},
+        @{n='StateOrProvince';e={$_.st}},
+        @{n='PostalCode';e={$_.postalCode}},
+        @{n='CountryOrRegion';e={ if ($_.co) { $_.co } else { $_.c } }},
+        @{n='HiddenFromAddressListsEnabled';e={$false}},
+        @{n='Notes';e={ if ($_.info) { $_.info } else { 'Импортирован из AD' } }} |
+    Export-Csv -Path $Export -NoTypeInformation -Encoding UTF8
+
+  Import-Csv $Export | Measure-Object
+  return
+}
+
+if ($PSCmdlet.ParameterSetName -eq "Import") {
+  if (-not (Test-Path $Import)) { throw "CSV not found: $Import" }
+  $rows = Import-Csv -Path $Import
+
+  $created=0; $updated=0; $skipped=0
+
+  foreach ($r in $rows) {
+      $name       = if ($r.PSObject.Properties.Match('Name').Count)       { [string]$r.Name } else { $null }
+      $display    = if ($r.PSObject.Properties.Match('DisplayName').Count){ [string]$r.DisplayName } else { $null }
+      $firstName  = if ($r.PSObject.Properties.Match('FirstName').Count)  { [string]$r.FirstName } else { $null }
+      $lastName   = if ($r.PSObject.Properties.Match('LastName').Count)   { [string]$r.LastName } else { $null }
+      $aliasCsv   = if ($r.PSObject.Properties.Match('Alias').Count)      { [string]$r.Alias } else { $null }
+      $email      = if ($r.PSObject.Properties.Match('ExternalEmailAddress').Count) { [string]$r.ExternalEmailAddress } else { $null }
+
+      if ($name)      { $name = $name.Trim() }
+      if ($display)   { $display = $display.Trim() }
+      if ($firstName) { $firstName = $firstName.Trim() }
+      if ($lastName)  { $lastName = $lastName.Trim() }
+      if ($aliasCsv)  { $aliasCsv = $aliasCsv.Trim() }
+      if ($email)     { $email = $email.Trim() }
+
+      if ([string]::IsNullOrWhiteSpace($email)) {
+          Write-Warning ("SKIP: '{0}' — пустой ExternalEmailAddress" -f $name); $skipped++; continue
+      }
+
+      $alias = $aliasCsv
+      if ([string]::IsNullOrWhiteSpace($alias)) {
+          if ($email -match '^(?<local>[^@]+)@') { $alias = $matches['local'] }
+      }
+
+      $mc = $null
+      $mc = Get-MailContact -Filter "ExternalEmailAddress -eq '$email'" -ErrorAction SilentlyContinue
+      if (-not $mc) { $mc = Get-MailContact -Filter "PrimarySmtpAddress -eq '$email'" -ErrorAction SilentlyContinue }
+      if (-not $mc -and $alias) { $mc = Get-MailContact -Filter "Alias -eq '$alias'" -ErrorAction SilentlyContinue }
+      if (-not $mc -and $name)  { $mc = Get-MailContact -Filter "DisplayName -eq '$name'" -ErrorAction SilentlyContinue }
+      if (-not $mc -and $name)  { $mc = Get-MailContact -Filter "Name -eq '$name'" -ErrorAction SilentlyContinue }
+
+      if (-not $mc) {
+          try {
+              if ($alias) {
+                  $mc = New-MailContact -Name $name -ExternalEmailAddress $email -OrganizationalUnit $TargetOU -FirstName $firstName -LastName $lastName -Alias $alias -ErrorAction Stop
+              } else {
+                  $mc = New-MailContact -Name $name -ExternalEmailAddress $email -OrganizationalUnit $TargetOU -FirstName $firstName -LastName $lastName -ErrorAction Stop
+              }
+              $created++; Write-Host ("CREATED: {0} <{1}>" -f $name,$email)
+          }
+          catch {
+              $msg = $_.Exception.Message
+              if ($msg -match 'already exists|уже существует|Object .* already exists') {
+                  $mc = $null
+                  $mc = Get-MailContact -Filter "ExternalEmailAddress -eq '$email'" -ErrorAction SilentlyContinue
+                  if (-not $mc) { $mc = Get-MailContact -Filter "PrimarySmtpAddress -eq '$email'" -ErrorAction SilentlyContinue }
+                  if (-not $mc -and $alias) { $mc = Get-MailContact -Filter "Alias -eq '$alias'" -ErrorAction SilentlyContinue }
+                  if (-not $mc -and $name)  { $mc = Get-MailContact -Filter "DisplayName -eq '$name'" -ErrorAction SilentlyContinue }
+                  if (-not $mc -and $name)  { $mc = Get-MailContact -Filter "Name -eq '$name'" -ErrorAction SilentlyContinue }
+
+                  if (-not $mc) {
+                      $adContact = $null
+                      if ($alias) { $adContact = Get-Contact -Filter "Alias -eq '$alias'" -ErrorAction SilentlyContinue }
+                      if (-not $adContact -and $name) { $adContact = Get-Contact -Filter "DisplayName -eq '$name'" -ErrorAction SilentlyContinue }
+                      if (-not $adContact -and $name) { $adContact = Get-Contact -Filter "Name -eq '$name'" -ErrorAction SilentlyContinue }
+
+                      if ($adContact) {
+                          try {
+                              Enable-MailContact -Identity $adContact.Identity -ExternalEmailAddress $email -ErrorAction Stop | Out-Null
+                              $mc = Get-MailContact -Identity $adContact.Identity -ErrorAction SilentlyContinue
+                              Write-Warning ("MAIL-ENABLED existing AD contact: '{0}' <{1}>" -f $name,$email)
+                          } catch {
+                              Write-Warning ("ERROR mail-enabling '{0}': {1}" -f $name,$_.Exception.Message)
+                          }
+                      }
+                  }
+
+                  if (-not $mc) {
+                      Write-Warning ("CONFLICT: '{0}' <{1}> — объект с таким именем существует, но по почте не найден. Пропуск." -f $name,$email)
+                      $skipped++; continue
+                  } else {
+                      Write-Warning ("FOUND-EXISTING: '{0}' уже существует; обновляю." -f $name)
+                  }
+              } else {
+                  Write-Warning ("ERROR create '{0}' <{1}>: {2}" -f $name,$email,$msg)
+                  $skipped++; continue
+              }
+          }
+      }
+
+      $company    = if ($r.PSObject.Properties.Match('Company').Count)    { [string]$r.Company } else { $null }
+      $department = if ($r.PSObject.Properties.Match('Department').Count) { [string]$r.Department } else { $null }
+      $title      = if ($r.PSObject.Properties.Match('Title').Count)      { [string]$r.Title } else { $null }
+      $phone      = if ($r.PSObject.Properties.Match('Phone').Count)      { [string]$r.Phone } else { $null }
+      $mobile     = if ($r.PSObject.Properties.Match('MobilePhone').Count){ [string]$r.MobilePhone } else { $null }
+      $fax        = if ($r.PSObject.Properties.Match('Fax').Count)        { [string]$r.Fax } else { $null }
+      $street     = if ($r.PSObject.Properties.Match('StreetAddress').Count){ [string]$r.StreetAddress } else { $null }
+      $city       = if ($r.PSObject.Properties.Match('City').Count)       { [string]$r.City } else { $null }
+      $state      = if ($r.PSObject.Properties.Match('StateOrProvince').Count){ [string]$r.StateOrProvince } else { $null }
+      $postal     = if ($r.PSObject.Properties.Match('PostalCode').Count) { [string]$r.PostalCode } else { $null }
+      $country    = if ($r.PSObject.Properties.Match('CountryOrRegion').Count){ [string]$r.CountryOrRegion } else { $null }
+      $notes      = if ($r.PSObject.Properties.Match('Notes').Count)      { [string]$r.Notes } else { $null }
+
+      $hidden = $null
+      if ($r.PSObject.Properties.Match('HiddenFromAddressListsEnabled').Count -and $r.HiddenFromAddressListsEnabled) {
+          $v = ($r.HiddenFromAddressListsEnabled.ToString()).Trim().ToLower()
+          if ($v -eq 'true') { $hidden = $true } elseif ($v -eq 'false') { $hidden = $false }
+      }
+
+      try {
+          if ($display) { Set-Contact -Identity $mc.Identity -DisplayName $display -ErrorAction SilentlyContinue | Out-Null }
+
+          Set-Contact -Identity $mc.Identity `
+              -FirstName $firstName `
+              -LastName $lastName `
+              -Company $company `
+              -Department $department `
+              -Title $title `
+              -Phone $phone `
+              -MobilePhone $mobile `
+              -Fax $fax `
+              -StreetAddress $street `
+              -City $city `
+              -StateOrProvince $state `
+              -PostalCode $postal `
+              -CountryOrRegion $country `
+              -Notes $notes `
+              -ErrorAction SilentlyContinue | Out-Null
+
+          Set-MailContact -Identity $mc.Identity -ExternalEmailAddress $email -ErrorAction SilentlyContinue | Out-Null
+          if ($alias -and $mc.Alias -ne $alias) { Set-MailContact -Identity $mc.Identity -Alias $alias -ErrorAction SilentlyContinue | Out-Null }
+          if ($hidden -ne $null) { Set-MailContact -Identity $mc.Identity -HiddenFromAddressListsEnabled:$hidden -ErrorAction SilentlyContinue | Out-Null }
+
+          $updated++; Write-Host ("UPDATED: {0} <{1}>" -f $mc.DisplayName,$email)
+      }
+      catch {
+          Write-Warning ("ERROR update '{0}' <{1}>: {2}" -f $name,$email,$_.Exception.Message)
+          $skipped++
+      }
+  }
+
+  Write-Host '==== Summary ===='
+  Write-Host ("Created: {0}" -f $created)
+  Write-Host ("Updated: {0}" -f $updated)
+  Write-Host ("Skipped: {0}" -f $skipped)
+}


### PR DESCRIPTION
## Summary
- add Contact.ps1 for exporting AD users and importing into Exchange
- replace hardcoded mtzd.ru domain references with neutral example.com values

## Testing
- `pwsh -NoLogo -NoProfile -Command "Get-Command"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: repository not signed / unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f034a39c832d95bb01267c43108b