### PR TITLE
Handle group search errors and remove BOM

### DIFF
--- a/scripts/utils.ps1
+++ b/scripts/utils.ps1
@@ -1,4 +1,4 @@
-﻿﻿# Экспортирует: Ensure-Module, New-SSHSess
+# Экспортирует: Ensure-Module, New-SSHSess
 
 function Ensure-Module([string]$Name) {
   if (-not (Get-Module -ListAvailable -Name $Name)) {


### PR DESCRIPTION
## Summary
- Remove UTF-8 BOM from utility and contact manager scripts
- Search contact group membership via Active Directory instead of Exchange filter

## Testing
- ⚠️ `pwsh -NoLogo -NoProfile -File scripts/Contact-Manager.ps1 -User test` (failed: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a9f99f0884832d9dee999024cdd927