### PR TITLE
Validate Domain before search in Contact-Manager

### DIFF
--- a/scripts/Contact-Manager.ps1
+++ b/scripts/Contact-Manager.ps1
@@ -227,7 +227,13 @@ if ($PSCmdlet.ParameterSetName -eq "Import") {
 
 # == Поиск контакта и отображение групп ==
 if ($PSCmdlet.ParameterSetName -eq "Search") {
-  if ($User -notlike "*@*") { $User = "$User@$Domain" }
+  if ($User -notlike "*@*") {
+    if ([string]::IsNullOrWhiteSpace($Domain)) {
+      Write-Host "Не задан Domain (config.ps1). Укажите полный адрес user@example.com." -ForegroundColor Red
+      return
+    }
+    $User = "$User@$Domain"
+  }
 
   $contact = Get-MailContact -Identity $User -ErrorAction SilentlyContinue
   if (-not $contact) {


### PR DESCRIPTION
## Summary
- Ensure the Contact-Manager script checks for a missing Domain before appending it during searches

## Testing
- `pwsh -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ff67a584832da0dcdf29aa7b5220