### PR TITLE
Check contact presence before group lookup

### DIFF
--- a/scripts/Contact-Manager.ps1
+++ b/scripts/Contact-Manager.ps1
@@ -230,8 +230,8 @@ if ($PSCmdlet.ParameterSetName -eq "Search") {
   if ($User -notlike "*@*") { $User = "$User@$Domain" }
 
   $contact = Get-MailContact -Identity $User -ErrorAction SilentlyContinue
-  if (-not $contact) {
-    Write-Host "Контакт $User не найден." -ForegroundColor Yellow
+  if (-not $contact -or -not $contact.DistinguishedName) {
+    Write-Host "контакт не найден/неполный" -ForegroundColor Yellow
     return
   }
 


### PR DESCRIPTION
## Summary
- verify contact object and DistinguishedName before group lookup
- skip group membership retrieval when contact is missing

## Testing
- `pwsh -NoLogo -NoProfile -File scripts/Contact-Manager.ps1 -User test@example.com` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ff77a464832da9ffb95ea2d028cc