### PR TITLE
Add staging flag for mailbox migration

### DIFF
--- a/Migration-Mailbox.ps1
+++ b/Migration-Mailbox.ps1
@@ -12,7 +12,10 @@ param(
   [switch]$Force,
 
   # Сухой прогон без переноса
-  [switch]$Dryrun
+  [switch]$Dryrun,
+
+  # Предстейдж: не удалять контакты
+  [switch]$Staged
 )
 
 # == Подключаем конфиг и функции ==
@@ -58,7 +61,7 @@ function Invoke-OneUser([string]$UserInput) {
   }
 
   # Выполняем перенос
-  $move = Invoke-MoveZimbraMailbox -UserInput $UserInput
+  $move = Invoke-MoveZimbraMailbox -UserInput $UserInput -Staged:$Staged
   $UserEmail = $move.UserEmail
   $Alias     = $move.Alias
 


### PR DESCRIPTION
## Summary
- add `-Staged` switch to `Invoke-MoveZimbraMailbox`
- skip contact deletion when `-Staged` is specified
- forward `-Staged` flag from `Migration-Mailbox.ps1`

## Testing
- ⚠️ `pwsh -NoLogo -NoProfile -Command "Set-StrictMode -Version Latest; . ./scripts/Move-ZimbraMailbox.ps1; (Get-Command Invoke-MoveZimbraMailbox).Parameters.Keys"` *(command not found: pwsh)*
- ⚠️ `apt-get update` *(403 Forbidden when accessing ubuntu repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68aa24499d58832d8a7ee6c88d3150bd