### PR TITLE
Handle contact groups without immediate removal

### DIFF
--- a/scripts/Move-ZimbraMailbox.ps1
+++ b/scripts/Move-ZimbraMailbox.ps1
@@ -10,23 +10,48 @@ function Invoke-MoveZimbraMailbox([string]$UserInput, [switch]$Staged) {
 
   # Проверка контакта и групп
   $contactGroups = @()
-  if (-not $Staged) {
-    try {
-      $contact = Get-MailContact -Identity $UserEmail -ErrorAction SilentlyContinue
-      if ($contact) {
-        Write-Host "Найден контакт $UserEmail. Сохраняю группы и удаляю контакт..."
-        $contactGroups = Get-DistributionGroup -ResultSize Unlimited -Filter "Members -eq '$($contact.DistinguishedName)'" -ErrorAction SilentlyContinue
-        if ($contactGroups) {
-          Write-Host ("Контакт состоит в группах: {0}" -f ($contactGroups.PrimarySmtpAddress -join ', '))
-        } else {
-          Write-Host "Контакт не состоит ни в одной группе."
-        }
-        Remove-MailContact -Identity $contact.Identity -Confirm:$false -ErrorAction Stop
-        Write-Host "Контакт удалён."
+  try {
+    $contact = Get-MailContact -Identity $UserEmail -ErrorAction SilentlyContinue
+    if ($contact) {
+      Write-Host "Найден контакт $UserEmail. Сохраняю группы..."
+      $contactGroups = Get-DistributionGroup -ResultSize Unlimited -Filter "Members -eq '$($contact.DistinguishedName)'" -ErrorAction SilentlyContinue
+      if ($contactGroups) {
+        Write-Host ("Контакт состоит в группах: {0}" -f ($contactGroups.PrimarySmtpAddress -join ', '))
+      } else {
+        Write-Host "Контакт не состоит ни в одной группе."
       }
-    } catch {
-      Write-Warning ("Не удалось обработать контакт {0}: {1}" -f $UserEmail, $_.Exception.Message)
+
+      if ($Staged) {
+        Write-Host "Добавляю пользователя в группы контакта..."
+        foreach ($g in $contactGroups) {
+          try {
+            Add-DistributionGroupMember -Identity $g.Identity -Member $UserEmail -ErrorAction Stop
+            Write-Host "Добавлен в группу $($g.PrimarySmtpAddress)"
+          } catch {
+            Write-Warning ("Не удалось добавить в группу {0}: {1}" -f $g.PrimarySmtpAddress, $_.Exception.Message)
+          }
+        }
+        Write-Host "Контакт остаётся до финального запуска."
+      } else {
+        Write-Host "Удаляю контакт $UserEmail..."
+        Remove-MailContact -Identity $contact.Identity -Confirm:$false -ErrorAction Stop
+        Write-Host "Контакт удалён. Проверяю членство пользователя..."
+        foreach ($g in $contactGroups) {
+          try {
+            $members = Get-DistributionGroupMember -Identity $g.Identity -ResultSize Unlimited -ErrorAction Stop
+            if ($members.PrimarySmtpAddress -contains $UserEmail) {
+              Write-Host "Пользователь состоит в группе $($g.PrimarySmtpAddress)"
+            } else {
+              Write-Warning "Пользователь отсутствует в группе $($g.PrimarySmtpAddress)"
+            }
+          } catch {
+            Write-Warning ("Не удалось проверить группу {0}: {1}" -f $g.PrimarySmtpAddress, $_.Exception.Message)
+          }
+        }
+      }
     }
+  } catch {
+    Write-Warning ("Не удалось обработать контакт {0}: {1}" -f $UserEmail, $_.Exception.Message)
   }
 
     # Mailbox: существует?
@@ -79,18 +104,6 @@ function Invoke-MoveZimbraMailbox([string]$UserInput, [switch]$Staged) {
     Write-Host "FullAccess уже есть."
   }
   Start-Sleep -Seconds 2
-
-  if ($contactGroups -and $contactGroups.Count -gt 0) {
-    Write-Host "Добавляю пользователя в группы бывшего контакта..."
-    foreach ($g in $contactGroups) {
-      try {
-        Add-DistributionGroupMember -Identity $g.Identity -Member $UserEmail -ErrorAction Stop
-        Write-Host "Добавлен в группу $($g.PrimarySmtpAddress)"
-      } catch {
-        Write-Warning ("Не удалось добавить в группу {0}: {1}" -f $g.PrimarySmtpAddress, $_.Exception.Message)
-      }
-    }
-  }
 
   # Готовим удалённый bash-скрипт imapsync
   $AdminImapB64   = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($AdminImapPasswordPlain))


### PR DESCRIPTION
## Summary
- Add staged contact group handling that adds the user to groups without removing the contact
- On final run, remove contact and verify group membership

## Testing
- `pwsh -NoLogo -NoProfile -Command ". ./scripts/Move-ZimbraMailbox.ps1; 'loaded'"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2631e988832d838d092e0043d494