### PR TITLE
Add activation step for mailbox migration

### DIFF
--- a/Migration-Mailbox.ps1
+++ b/Migration-Mailbox.ps1
@@ -61,7 +61,7 @@ function Invoke-OneUser([string]$UserInput) {
   }
 
   # Выполняем перенос
-  $move = Invoke-MoveZimbraMailbox -UserInput $UserInput -Staged:$Staged
+  $move = Invoke-MoveZimbraMailbox -UserInput $UserInput -Staged:$Staged -Activate:$Force
   $UserEmail = $move.UserEmail
   $Alias     = $move.Alias
 


### PR DESCRIPTION
## Summary
- Pass `-Activate` to `Invoke-MoveZimbraMailbox` when running with `-Force`
- Allow `Invoke-MoveZimbraMailbox` to remove contact, enable AD account, and unhide mailbox when `-Activate` is specified

## Testing
- `pwsh -NoLogo -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('Migration-Mailbox.ps1',[ref]$null,[ref]$null); [System.Management.Automation.Language.Parser]::ParseFile('scripts/Move-ZimbraMailbox.ps1',[ref]$null,[ref]$null)"` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68aa270089bc832d942f80451a22ff89