### PR TITLE
Adjust staged mailbox creation

### DIFF
--- a/scripts/Move-ZimbraMailbox.ps1
+++ b/scripts/Move-ZimbraMailbox.ps1
@@ -54,10 +54,7 @@ function Invoke-MoveZimbraMailbox([string]$UserInput, [switch]$Staged, [switch]$
         $TempEmail = "$AliasTemp@$Domain"
         try {
           Write-Host "Переименовываю временный ящик $TempEmail в $UserEmail..."
-          Set-Mailbox $TempEmail -PrimarySmtpAddress $UserEmail -EmailAddresses @{Add=$UserEmail; Remove=$TempEmail} -ErrorAction Stop
-          $adTemp = Get-ADUser -Identity $AliasTemp -Properties DistinguishedName -ErrorAction Stop
-          Rename-ADObject -Identity $adTemp.DistinguishedName -NewName $Alias -ErrorAction Stop
-          Set-ADUser -Identity $adTemp -SamAccountName $Alias -UserPrincipalName $UserEmail -ErrorAction Stop
+          Set-Mailbox $TempEmail -PrimarySmtpAddress $UserEmail -EmailAddresses @{Add=$UserEmail; Remove=$TempEmail} -Alias $Alias -ErrorAction Stop
         } catch {
           Write-Warning ("Не удалось переименовать временный ящик {0}: {1}" -f $TempEmail, $_.Exception.Message)
         }
@@ -78,9 +75,9 @@ function Invoke-MoveZimbraMailbox([string]$UserInput, [switch]$Staged, [switch]$
     if ($Activate) {
       Write-Warning "Временный mailbox $TempEmail не найден."
     } elseif ($Staged -and $contact) {
-      Write-Host "Mailbox не найден. Enable-Mailbox для '$AliasTemp'..."
-      Enable-Mailbox -Identity $AliasTemp -PrimarySmtpAddress $TempEmail -Alias $AliasTemp -ErrorAction Stop | Out-Null
-      Disable-ADAccount -Identity $AliasTemp -ErrorAction Stop
+      Write-Host "Mailbox не найден. Enable-Mailbox для '$Alias' с временным алиасом '$AliasTemp'..."
+      Enable-Mailbox -Identity $Alias -PrimarySmtpAddress $TempEmail -Alias $AliasTemp -ErrorAction Stop | Out-Null
+      Disable-ADAccount -Identity $Alias -ErrorAction Stop
       Set-Mailbox -Identity $TempEmail -HiddenFromAddressListsEnabled $true -ErrorAction Stop
     } else {
       Write-Host "Mailbox не найден. Enable-Mailbox для '$Alias'..."


### PR DESCRIPTION
## Summary
- create temporary staged mailbox using original account identity and disable account
- simplify activation rename logic and set alias back to original name

## Testing
- `pwsh -NoLogo -NoProfile -Command "if (Get-Command Invoke-Pester -ErrorAction SilentlyContinue) { Invoke-Pester -Path tests } else { Write-Host 'Pester not installed or tests not found' }"` *(fails: command not found)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa33b7cefc832d8748843bb2a001af