### PR TITLE
Split Set-Mailbox operations and keep AD accounts active during staging

### DIFF
--- a/scripts/Move-ZimbraMailbox.ps1
+++ b/scripts/Move-ZimbraMailbox.ps1
@@ -25,8 +25,13 @@ function Invoke-MoveZimbraMailbox([string]$UserInput, [switch]$Staged, [switch]$
         Write-Host "Добавляю пользователя в группы контакта..."
         foreach ($g in $contactGroups) {
           try {
-            Add-DistributionGroupMember -Identity $g.Identity -Member $UserEmail -ErrorAction Stop
-            Write-Host "Добавлен в группу $($g.PrimarySmtpAddress)"
+            $members = Get-DistributionGroupMember -Identity $g.Identity -ResultSize Unlimited -ErrorAction Stop
+            if ($members.PrimarySmtpAddress -notcontains $UserEmail) {
+              Add-DistributionGroupMember -Identity $g.Identity -Member $UserEmail -ErrorAction SilentlyContinue
+              Write-Host "Добавлен в группу $($g.PrimarySmtpAddress)"
+            } else {
+              Write-Host "Пользователь уже состоит в группе $($g.PrimarySmtpAddress)"
+            }
           } catch {
             Write-Warning ("Не удалось добавить в группу {0}: {1}" -f $g.PrimarySmtpAddress, $_.Exception.Message)
           }
@@ -54,7 +59,8 @@ function Invoke-MoveZimbraMailbox([string]$UserInput, [switch]$Staged, [switch]$
         $TempEmail = "$AliasTemp@$Domain"
         try {
           Write-Host "Переименовываю временный ящик $TempEmail в $UserEmail..."
-          Set-Mailbox $TempEmail -PrimarySmtpAddress $UserEmail -EmailAddresses @{Add=$UserEmail; Remove=$TempEmail} -Alias $Alias -ErrorAction Stop
+          Set-Mailbox $TempEmail -PrimarySmtpAddress $UserEmail -Alias $Alias -ErrorAction Stop
+          Set-Mailbox $UserEmail -EmailAddresses @{Add=$UserEmail; Remove=$TempEmail} -ErrorAction Stop
         } catch {
           Write-Warning ("Не удалось переименовать временный ящик {0}: {1}" -f $TempEmail, $_.Exception.Message)
         }
@@ -77,15 +83,18 @@ function Invoke-MoveZimbraMailbox([string]$UserInput, [switch]$Staged, [switch]$
     } elseif ($Staged -and $contact) {
       Write-Host "Mailbox не найден. Enable-Mailbox для '$Alias' с временным алиасом '$AliasTemp'..."
       Enable-Mailbox -Identity $Alias -PrimarySmtpAddress $TempEmail -Alias $AliasTemp -ErrorAction Stop | Out-Null
-      Disable-ADAccount -Identity $Alias -ErrorAction Stop
       Set-Mailbox -Identity $TempEmail -HiddenFromAddressListsEnabled $true -ErrorAction Stop
+      try {
+        Set-ADUser -Identity $Alias -EmailAddress $UserEmail -ErrorAction Stop
+      } catch {
+        Write-Warning ("Не удалось обновить поле mail для {0}: {1}" -f $Alias, $_.Exception.Message)
+      }
       Write-Host "Mailbox включён. Пауза 60 сек для репликации..."
       Start-Sleep -Seconds 60
     } else {
       Write-Host "Mailbox не найден. Enable-Mailbox для '$Alias'..."
       Enable-Mailbox -Identity $Alias -PrimarySmtpAddress $UserEmail -Alias $Alias -ErrorAction Stop | Out-Null
       if ($Staged) {
-        Disable-ADAccount -Identity $Alias -ErrorAction Stop
         Set-Mailbox -Identity $UserEmail -HiddenFromAddressListsEnabled $true -ErrorAction Stop
       }
       Write-Host "Mailbox включён. Пауза 60 сек для репликации..."
@@ -95,7 +104,6 @@ function Invoke-MoveZimbraMailbox([string]$UserInput, [switch]$Staged, [switch]$
 
   if ($Activate) {
     try {
-      Enable-ADAccount -Identity $Alias -ErrorAction Stop
       Set-Mailbox -Identity $UserEmail -HiddenFromAddressListsEnabled $false -ErrorAction Stop
       Write-Host "Учетная запись активирована."
     } catch {


### PR DESCRIPTION
## Summary
- avoid PrimarySmtpAddress+EmailAddresses conflict when renaming temporary mailbox
- keep staged mailboxes hidden instead of disabling AD accounts
- restore AD user's mail attribute to original address during staging

## Testing
- `pwsh -NoLogo -NoProfile -Command "Get-Command"` *(fails: command not found: pwsh)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*


------
https://chatgpt.com/codex/tasks/task_e_68aa36045eb4832daded0db2ed4f17aa