### PR TITLE
Add distribution group export and relocate data paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ ImapSyncLogs
 scripts/contacts.csv
 test-function/test.csv
 test.csv
+lists/*
+!lists/.gitkeep

--- a/README.md
+++ b/README.md
@@ -223,17 +223,22 @@ su - zimbra -c 'zmprov ga ivan.petrov_old@example.com | egrep "mail|zimbraMailAl
 ## Работа с контактами
 
 ### Экспорт и импорт
-Скрипт `scripts/Contact-Manager.ps1` может экспортировать контакты из Active Directory в CSV и импортировать их в Exchange.
+Скрипт `Contact.ps1` может экспортировать контакты из Active Directory в CSV и импортировать их в Exchange. Все CSV сохраняются в папку `lists` в корне репозитория.
 
 ```powershell
 # Экспорт из AD
-./scripts/Contact-Manager.ps1 -Export contacts.csv
+./Contact.ps1 -Export contacts.csv
 
 # Импорт в OU из CSV
-./scripts/Contact-Manager.ps1 -Import contacts.csv
+./Contact.ps1 -Import contacts.csv
 
 # Импорт только одного контакта
-./scripts/Contact-Manager.ps1 -Import contacts.csv -Contact ivan.petrov@example.com
+./Contact.ps1 -Import contacts.csv -Contact ivan.petrov@example.com
+```
+
+### Экспорт групп рассылки из Zimbra
+```powershell
+./Contact.ps1 -ExportDistributionGroup
 ```
 
 ### Поиск контакта

--- a/scripts/config.example.ps1
+++ b/scripts/config.example.ps1
@@ -36,7 +36,7 @@ $PMGUser                = ""
 $PMGPasswordPlain       = ""
 
 # Логи на Windows
-$LocalLogDir            = "$PSScriptRoot\ImapSyncLogs"
+$LocalLogDir            = Join-Path (Split-Path $PSScriptRoot -Parent) 'ImapSyncLogs'
 
 # Хост для подключения к Exchange Management PowerShell (если локально — оставь localhost)
 $ExchangeMgmtHost       = "localhost"


### PR DESCRIPTION
## Summary
- export Zimbra distribution lists and members to CSV via `Contact.ps1 -ExportDistributionGroup`
- store all CSV files under the new `lists` folder and add single-contact import option
- move log output path to project root

## Testing
- `pwsh -NoLogo -NoProfile -Command "Write-Host 'test'"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab236d2ce8832d8e210456134899a6