### PR TITLE
Fix quoting for Zimbra distribution list export

### DIFF
--- a/Contact.ps1
+++ b/Contact.ps1
@@ -215,11 +215,11 @@ if ($PSCmdlet.ParameterSetName -eq 'ExportDistributionGroup') {
   Ensure-Module Posh-SSH
   $sess = New-SSHSess -SshHost $ZimbraSshHost -SshUser $ZimbraSshUser -SshPass $ZimbraSshPasswordPlain
   try {
-    $cmd = "bash -lc 'su - zimbra -c \"zmprov gadl\"'"
+    $cmd = 'bash -lc ''su - zimbra -c "zmprov gadl"'''
     $res = Invoke-SSHCommand -SessionId $sess.SessionId -Command $cmd
     $lists = $res.Output | Where-Object { $_ }
     foreach ($dl in $lists) {
-      $cmd2 = ("bash -lc 'su - zimbra -c \"zmprov gdlm {0}\"'" -f $dl)
+      $cmd2 = ('bash -lc ''su - zimbra -c "zmprov gdlm {0}"''' -f $dl)
       $res2 = Invoke-SSHCommand -SessionId $sess.SessionId -Command $cmd2
       $members = $res2.Output | Where-Object { $_ }
       $fileName = ($dl -replace '@','_') -replace '\.','_'


### PR DESCRIPTION
## Summary
- fix PowerShell quoting for Zimbra zmprov commands in Contact.ps1

## Testing
- `pwsh -NoProfile -Command "Get-Command"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab26ee7f68832d94d66f21076e220c