### PR TITLE
Use config-based OU paths for contacts and groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ Install-Module Posh-SSH -Scope AllUsers -Force
 
 ```powershell
 $Domain                 = "example.com"
+# OU для экспорта/импорта контактов и создания групп рассылки
+$ContactsSourceOU       = ""
+$ContactsTargetOU       = ""
+$DistributionGroupsOU   = ""
+
 $AdminLogin             = "EXCH\imapadmin"        # учётка, получающая FullAccess и IMAP proxy-auth
 
 $ExchangeImapHost       = "mail01.example.com"
@@ -244,7 +249,7 @@ su - zimbra -c 'zmprov ga ivan.petrov_old@example.com | egrep "mail|zimbraMailAl
 ```
 
 ### Импорт групп рассылки в Exchange
-CSV из `lists/distribution_list` будут использованы для создания групп и добавления членов, найденных в Exchange.
+CSV из `lists/distribution_list` будут использованы для создания групп в OU `$DistributionGroupsOU` и добавления членов, найденных в Exchange.
 
 ```powershell
 ./Contact.ps1 -ImportGroups

--- a/scripts/config.example.ps1
+++ b/scripts/config.example.ps1
@@ -4,9 +4,11 @@
 # Домен почты
 $Domain                 = ""
 
-# OU для экспорта и импорта контактов
+# OU для экспорта/импорта контактов и создания групп рассылки
 $ContactsSourceOU       = ""
 $ContactsTargetOU       = ""
+# OU для новых групп рассылки (Distribution Groups) в Active Directory
+$DistributionGroupsOU   = ""
 
 # Админ (используется и как IMAP proxy-auth, и для FullAccess)
 $AdminLogin             = ""


### PR DESCRIPTION
## Summary
- allow Contact.ps1 to export with `-Export` switch using default `lists/contacts.csv`
- move contact and distribution group OU paths into `config.ps1`
- document new configuration fields and group OU usage

## Testing
- `pwsh -NoLogo -NoProfile -File ./Contact.ps1 -Export` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab30681c28832dadf2554e19b217f0