### PR TITLE
Update PMG transport for imported distribution groups

### DIFF
--- a/Contact.ps1
+++ b/Contact.ps1
@@ -24,6 +24,7 @@ param(
 
 . "$PSScriptRoot/scripts/config.ps1"
 . "$PSScriptRoot/scripts/utils.ps1"
+. "$PSScriptRoot/scripts/Update-PMGTransport.ps1"
 
 $ListsDir = Join-Path $PSScriptRoot 'lists'
 if (-not (Test-Path $ListsDir)) { New-Item -Path $ListsDir -ItemType Directory -Force | Out-Null }
@@ -245,6 +246,9 @@ if ($PSCmdlet.ParameterSetName -eq 'ImportGroups') {
           continue
         }
       }
+      $pmg = Update-PMGTransport -UserEmail $dl
+      if ($pmg.Success) { Write-Host ("PMG transport: {0}" -f $pmg.Line) }
+      else { Write-Warning ("PMTransport error for '{0}': {1}" -f $dl,$pmg.Error) }
       foreach ($m in $g.Group) {
         $member = $m.Member.Trim()
         $rcp = Get-Recipient -Identity $member -ErrorAction SilentlyContinue

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ su - zimbra -c 'zmprov ga ivan.petrov_old@example.com | egrep "mail|zimbraMailAl
 ```
 
 ### Импорт групп рассылки в Exchange
-CSV из `lists/distribution_list` будут использованы для создания групп в OU `$DistributionGroupsOU` и добавления членов, найденных в Exchange.
+CSV из `lists/distribution_list` будут использованы для создания групп в OU `$DistributionGroupsOU`, добавления членов, найденных в Exchange, и создания записи `transport` на PMG для каждой группы.
 
 ```powershell
 ./Contact.ps1 -ImportGroups


### PR DESCRIPTION
## Summary
- source PMG transport helper in contact script
- create PMG transport entry when importing distribution groups
- document PMG transport update for groups

## Testing
- ⚠️ `pwsh -NoLogo -NoProfile -Command "Get-Help ./Contact.ps1" | head -n 20` (command not found: pwsh)


------
https://chatgpt.com/codex/tasks/task_e_68ab3f0ee04c832dacb31712aa4bd63d