### PR TITLE
feat: add force option for group import

### DIFF
--- a/Contact.ps1
+++ b/Contact.ps1
@@ -18,6 +18,9 @@ param(
   [Parameter(ParameterSetName="ImportGroups", Mandatory=$true)]
   [switch]$ImportGroups,
 
+  [Parameter(ParameterSetName="ImportGroups")]
+  [switch]$Force,
+
   [Parameter(ParameterSetName="ExportDistributionGroup", Mandatory=$true)]
   [switch]$ExportDistributionGroup
 )
@@ -25,6 +28,7 @@ param(
 . "$PSScriptRoot/scripts/config.ps1"
 . "$PSScriptRoot/scripts/utils.ps1"
 . "$PSScriptRoot/scripts/Update-PMGTransport.ps1"
+. "$PSScriptRoot/scripts/Rename-ZimbraDistributionList.ps1"
 
 $ListsDir = Join-Path $PSScriptRoot 'lists'
 if (-not (Test-Path $ListsDir)) { New-Item -Path $ListsDir -ItemType Directory -Force | Out-Null }
@@ -33,7 +37,7 @@ if (-not (Test-Path $DlDir)) { New-Item -Path $DlDir -ItemType Directory -Force 
 
 if ($PSCmdlet.ParameterSetName -eq 'Export') {
   Ensure-Module ActiveDirectory
-  if (-not $ContactsSourceOU) { throw "˜˜ ˜˜˜˜˜ ContactsSourceOU ˜ config.ps1" }
+  if (-not $ContactsSourceOU) { throw "ËœËœ ËœËœËœËœËœ ContactsSourceOU Ëœ config.ps1" }
   if (-not $ExportPath) { $ExportPath = 'contacts.csv' }
   if (-not (Split-Path $ExportPath -IsAbsolute)) { $ExportPath = Join-Path $ListsDir $ExportPath }
   Get-ADUser -SearchBase $ContactsSourceOU `
@@ -60,7 +64,7 @@ if ($PSCmdlet.ParameterSetName -eq 'Export') {
         @{n='PostalCode';e={$_.postalCode}},
         @{n='CountryOrRegion';e={ if ($_.co) { $_.co } else { $_.c } }},
         @{n='HiddenFromAddressListsEnabled';e={$false}},
-        @{n='Notes';e={ if ($_.info) { $_.info } else { '˜˜˜˜˜˜˜˜˜˜˜˜ ˜˜ AD' } }} |
+        @{n='Notes';e={ if ($_.info) { $_.info } else { 'ËœËœËœËœËœËœËœËœËœËœËœËœ ËœËœ AD' } }} |
     Export-Csv -Path $ExportPath -NoTypeInformation -Encoding UTF8
 
   Import-Csv $ExportPath | Measure-Object
@@ -69,7 +73,7 @@ if ($PSCmdlet.ParameterSetName -eq 'Export') {
 
 if ($PSCmdlet.ParameterSetName -eq 'Import') {
   Ensure-Module ActiveDirectory
-  if (-not $ContactsTargetOU) { throw "˜˜ ˜˜˜˜˜ ContactsTargetOU ˜ config.ps1" }
+  if (-not $ContactsTargetOU) { throw "ËœËœ ËœËœËœËœËœ ContactsTargetOU Ëœ config.ps1" }
   if (-not $ImportPath) { $ImportPath = 'contacts.csv' }
   if (-not (Split-Path $ImportPath -IsAbsolute)) { $ImportPath = Join-Path $ListsDir $ImportPath }
   if (-not (Test-Path $ImportPath)) { throw "CSV not found: $ImportPath" }
@@ -102,7 +106,7 @@ if ($PSCmdlet.ParameterSetName -eq 'Import') {
       if ($email)     { $email = $email.Trim() }
 
       if ([string]::IsNullOrWhiteSpace($email)) {
-          Write-Warning ("SKIP: '{0}' ˜ ˜˜˜˜˜˜ ExternalEmailAddress" -f $name); $skipped++; continue
+          Write-Warning ("SKIP: '{0}' Ëœ ËœËœËœËœËœËœ ExternalEmailAddress" -f $name); $skipped++; continue
       }
 
       $alias = $aliasCsv
@@ -128,7 +132,7 @@ if ($PSCmdlet.ParameterSetName -eq 'Import') {
           }
           catch {
               $msg = $_.Exception.Message
-              if ($msg -match 'already exists|˜˜˜ ˜˜˜˜˜˜˜˜˜˜|Object .* already exists') {
+              if ($msg -match 'already exists|ËœËœËœ ËœËœËœËœËœËœËœËœËœËœ|Object .* already exists') {
                   $mc = $null
                   $mc = Get-MailContact -Filter "ExternalEmailAddress -eq '$email'" -ErrorAction SilentlyContinue
                   if (-not $mc) { $mc = Get-MailContact -Filter "PrimarySmtpAddress -eq '$email'" -ErrorAction SilentlyContinue }
@@ -154,10 +158,10 @@ if ($PSCmdlet.ParameterSetName -eq 'Import') {
                   }
 
                   if (-not $mc) {
-                      Write-Warning ("CONFLICT: '{0}' <{1}> ˜ ˜˜˜˜˜˜ ˜ ˜˜˜˜˜ ˜˜˜˜˜˜ ˜˜˜˜˜˜˜˜˜˜, ˜˜ ˜˜ ˜˜˜˜˜ ˜˜ ˜˜˜˜˜˜. ˜˜˜˜˜˜˜." -f $name,$email)
+                      Write-Warning ("CONFLICT: '{0}' <{1}> Ëœ ËœËœËœËœËœËœ Ëœ ËœËœËœËœËœ ËœËœËœËœËœËœ ËœËœËœËœËœËœËœËœËœËœ, ËœËœ ËœËœ ËœËœËœËœËœ ËœËœ ËœËœËœËœËœËœ. ËœËœËœËœËœËœËœ." -f $name,$email)
                       $skipped++; continue
                   } else {
-                      Write-Warning ("FOUND-EXISTING: '{0}' ˜˜˜ ˜˜˜˜˜˜˜˜˜˜; ˜˜˜˜˜˜˜˜." -f $name)
+                      Write-Warning ("FOUND-EXISTING: '{0}' ËœËœËœ ËœËœËœËœËœËœËœËœËœËœ; ËœËœËœËœËœËœËœËœ." -f $name)
                   }
               } else {
                   Write-Warning ("ERROR create '{0}' <{1}>: {2}" -f $name,$email,$msg)
@@ -226,9 +230,14 @@ if ($PSCmdlet.ParameterSetName -eq 'Import') {
 }
 
 if ($PSCmdlet.ParameterSetName -eq 'ImportGroups') {
-  if (-not $DistributionGroupsOU) { throw "˜˜ ˜˜˜˜˜ DistributionGroupsOU ˜ config.ps1" }
-  if (-not (Test-Path $DlDir)) { throw "Directory not found: $DlDir" }
-  $files = Get-ChildItem -Path $DlDir -Filter '*.csv' -ErrorAction SilentlyContinue
+      if ($Force) {
+        $pmg = Update-PMGTransport -UserEmail $dl
+        if ($pmg.Success) { Write-Host ("PMG transport: {0}" -f $pmg.Line) }
+        else { Write-Warning ("PMTransport error for '{0}': {1}" -f $dl,$pmg.Error) }
+        $rn = Rename-ZimbraDistributionList -ListEmail $dl -Alias $alias
+        if ($rn.Success) { Write-Host ("RENAMED Zimbra: {0} -> {1}" -f $dl,$rn.NewEmail) }
+        else { Write-Warning ("Rename error for '{0}': {1}" -f $dl,$rn.Error) }
+      }
   foreach ($f in $files) {
     $rows = Import-Csv -Path $f.FullName | Where-Object { $_.Member -and $_.Member -notmatch '^#' -and $_.Member -ne 'members' }
     $grouped = $rows | Group-Object DistributionList

--- a/README.md
+++ b/README.md
@@ -249,10 +249,10 @@ su - zimbra -c 'zmprov ga ivan.petrov_old@example.com | egrep "mail|zimbraMailAl
 ```
 
 ### Импорт групп рассылки в Exchange
-CSV из `lists/distribution_list` будут использованы для создания групп в OU `$DistributionGroupsOU`, добавления членов, найденных в Exchange, и создания записи `transport` на PMG для каждой группы.
+CSV из `lists/distribution_list` будут использованы для создания групп в OU `$DistributionGroupsOU` и добавления членов, найденных в Exchange. С ключом `-Force` скрипт также обновит запись `transport` на PMG и переименует исходную группу в Zimbra, добавив суффикс `_old`.
 
 ```powershell
-./Contact.ps1 -ImportGroups
+./Contact.ps1 -ImportGroups [-Force]
 ```
 
 ### Поиск контакта

--- a/scripts/Rename-ZimbraDistributionList.ps1
+++ b/scripts/Rename-ZimbraDistributionList.ps1
@@ -1,0 +1,25 @@
+# Требует: config.ps1, utils.ps1
+# Экспортирует: Rename-ZimbraDistributionList
+
+function Rename-ZimbraDistributionList([string]$ListEmail,[string]$Alias) {
+  Ensure-Module Posh-SSH
+  $zSess = New-SSHSess -SshHost $ZimbraSshHost -SshUser $ZimbraSshUser -SshPass $ZimbraSshPasswordPlain
+  if (-not $zSess) { return @{ Success=$false; Error="SSH к $ZimbraSshHost не установлен" } }
+
+  $oldEmail = "{0}_old@{1}" -f $Alias, $Domain
+  try {
+    $cmd = ("bash -lc 'su - zimbra -c ""zmprov renameDistributionList {0} {1}""'") -f $ListEmail, $oldEmail
+    $rn = Invoke-SSHCommand -SessionId $zSess.SessionId -Command $cmd
+    if ($rn.ExitStatus -ne 0) {
+      $oldEmail = "{0}_old_{1}@{2}" -f $Alias, (Get-Date -Format "yyyyMMddHHmm"), $Domain
+      $cmd2 = ("bash -lc 'su - zimbra -c ""zmprov renameDistributionList {0} {1}""'") -f $ListEmail, $oldEmail
+      $rn2 = Invoke-SSHCommand -SessionId $zSess.SessionId -Command $cmd2
+      if ($rn2.ExitStatus -ne 0) {
+        return @{ Success=$false; Error=($rn2.Error -join ' ') }
+      }
+    }
+    return @{ Success=$true; NewEmail=$oldEmail }
+  } finally {
+    Remove-SSHSession -SessionId $zSess.SessionId | Out-Null
+  }
+}


### PR DESCRIPTION
## Summary
- add optional `-Force` to `Contact.ps1 -ImportGroups` to set PMG transport and rename existing Zimbra group with `_old`
- document and support group renaming via new `Rename-ZimbraDistributionList` script

## Testing
- `pwsh -NoLogo -NoProfile -Command "Get-Help -Name ./Contact.ps1 > $null"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abfffdeeac832da38bf88d813e580e