### PR TITLE
fix: handle empty alias and allow external group senders

### DIFF
--- a/scripts/Move-ZimbraMailbox.ps1
+++ b/scripts/Move-ZimbraMailbox.ps1
@@ -25,6 +25,7 @@ function Invoke-MoveZimbraMailbox([string]$UserInput, [switch]$Staged, [switch]$
         Write-Host "Добавляю пользователя в группы контакта..."
         foreach ($g in $contactGroups) {
           try {
+            Set-DistributionGroup -Identity $g.Identity -RequireSenderAuthenticationEnabled $false -ErrorAction SilentlyContinue | Out-Null
             $members = Get-DistributionGroupMember -Identity $g.Identity -ResultSize Unlimited -ErrorAction Stop
             if ($members.PrimarySmtpAddress -notcontains $UserEmail) {
               Add-DistributionGroupMember -Identity $g.Identity -Member $UserEmail -ErrorAction SilentlyContinue

--- a/scripts/Rename-ZimbraMailbox.ps1
+++ b/scripts/Rename-ZimbraMailbox.ps1
@@ -6,6 +6,11 @@ function Rename-ZimbraMailbox([string]$UserEmail,[string]$Alias) {
   $zSess = New-SSHSess -SshHost $ZimbraSshHost -SshUser $ZimbraSshUser -SshPass $ZimbraSshPasswordPlain
   if (-not $zSess) { return @{ Success=$false; Error="SSH к $ZimbraSshHost не установлен" } }
 
+  if ([string]::IsNullOrWhiteSpace($Alias)) {
+    if ($UserEmail -match '^(?<local>[^@]+)@') { $Alias = $matches['local'] }
+    else { return @{ Success=$false; Error="Не удалось определить Alias" } }
+  }
+
   $oldEmail = "{0}_old@{1}" -f $Alias, $Domain
   try {
     $cmd = ("bash -lc 'su - zimbra -c ""zmprov ra {0} {1}""'") -f $UserEmail, $oldEmail


### PR DESCRIPTION
## Summary
- derive alias from email when renaming Zimbra accounts to avoid blank alias errors
- ensure distribution groups allow external senders when adding migrated members

## Testing
- `pwsh -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y powershell` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac025729dc832db2f9cabe64538cf1