### PR TITLE
Fix mailbox rename and imapsync retry delay

### DIFF
--- a/scripts/Move-ZimbraMailbox.ps1
+++ b/scripts/Move-ZimbraMailbox.ps1
@@ -97,7 +97,7 @@ function Invoke-MoveZimbraMailbox([string]$UserInput, [switch]$Staged, [switch]$
     try {
       Write-Host "Переименовываю временный ящик $TempEmail в $UserEmail..."
       Set-Mailbox $TempEmail -PrimarySmtpAddress $UserEmail -Alias $Alias -ErrorAction Stop
-      Set-Mailbox $UserEmail -EmailAddresses @{Add=$UserEmail; Remove=$TempEmail} -ErrorAction Stop
+      Set-Mailbox $UserEmail -EmailAddresses @{Remove="smtp:$TempEmail"} -ErrorAction Stop
       $mailboxIdentity = $UserEmail
     } catch {
       Write-Warning ("Не удалось переименовать временный ящик {0}: {1}" -f $TempEmail, $_.Exception.Message)
@@ -182,7 +182,7 @@ exec > >(tee -a "$LOGFILE") 2>&1
 echo "[imapsync] start for __USER_EMAIL__ at $TS, log: $LOGFILE"
 
 TRIES=5
-DELAY=15
+DELAY=10
 attempt=1
 rc=111
 
@@ -219,7 +219,6 @@ while [ $attempt -le $TRIES ]; do
   if [ $attempt -lt $TRIES ]; then
     echo "[imapsync] will retry after ${DELAY}s ..."
     sleep $DELAY
-    DELAY=$((DELAY*2))
   fi
   attempt=$((attempt+1))
 done


### PR DESCRIPTION
## Summary
- ensure temporary alias `_1` is removed when activating mailbox
- retry imapsync up to five times with 10s delay on failure

## Testing
- `pwsh -NoLogo -Command "try { Invoke-ScriptAnalyzer -Path 'scripts/Move-ZimbraMailbox.ps1' } catch { Write-Host $_ }"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad75df4f6c832dbd78e1a4075da8bf