### PR TITLE
Use user email for Exchange IMAP login

### DIFF
--- a/Migration-Mailbox.ps1
+++ b/Migration-Mailbox.ps1
@@ -73,7 +73,10 @@ function Invoke-OneUser([string]$UserInput) {
       $TempEmail = "$AliasTemp@$Domain"
       try {
         Write-Host "Переименовываю ящик $TempEmail в $UserEmail..."
-        Set-Mailbox -Identity $AliasTemp -PrimarySmtpAddress $UserEmail -Alias $Alias -EmailAddresses @{Add=$UserEmail; Remove=$TempEmail} -ErrorAction Stop
+        # Нельзя одновременно указывать PrimarySmtpAddress и EmailAddresses,
+        # поэтому сначала меняем основные параметры, а затем убираем временный адрес.
+        Set-Mailbox -Identity $AliasTemp -PrimarySmtpAddress $UserEmail -Alias $Alias -ErrorAction Stop
+        Set-Mailbox -Identity $UserEmail -EmailAddresses @{Remove=$TempEmail} -ErrorAction Stop
         Write-Host "Переименование Exchange-ящика выполнено."
       } catch {
         Write-Warning ("Не удалось переименовать Exchange-ящик {0}: {1}" -f $TempEmail, $_.Exception.Message)

--- a/scripts/Move-ZimbraMailbox.ps1
+++ b/scripts/Move-ZimbraMailbox.ps1
@@ -218,7 +218,10 @@ exit $rc
     "__REMOTE_LOG__"          = $RemoteLog
     "__ADMIN_IMAP_B64__"      = $AdminImapB64
     "__USER_EMAIL__"          = $UserEmail
-    "__USER2__"               = $mailboxIdentity
+    # Для авторизации на Exchange используем тот же логин, что и на Zimbra,
+    # даже если сам почтовый ящик временно создан с суффиксом "_1".
+    # Это позволяет входить по UPN без добавления временного алиаса.
+    "__USER2__"               = $UserEmail
     "__ZIMBRA_IMAP_HOST__"    = $ZimbraImapHost
     "__ZIMBRA_IMAP_PORT__"    = "$ZimbraImapPort"
     "__EXCHANGE_IMAP_HOST__"  = $ExchangeImapHost


### PR DESCRIPTION
## Summary
- Log into Exchange using the original user email instead of the temporary `_1` alias during staged migrations
- Rename the Exchange mailbox in two steps to avoid `PrimarySmtpAddress` and `EmailAddresses` conflicts

## Testing
- `pwsh -NoLogo -NoProfile -Command ". ./scripts/Move-ZimbraMailbox.ps1; Get-Command Invoke-MoveZimbraMailbox"` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb8fef8d4832db94888977fdcbefe